### PR TITLE
Feature/issue 20 deck analysis versioning

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,7 +49,8 @@ make ci          # Run check + test (use before commits)
 1. **`src/`** - Core business logic (parser, services)
    - `parser/log_parser.py` - Parses MTGA Player.log JSON events
    - `services/scryfall.py` - Downloads/caches Scryfall bulk data
-   - `services/import_service.py` - Orchestrates import workflow
+   - `services/import_service.py` - Orchestrates import workflow (used by management command and `stats/views/imports.py`)
+   - `services/play_advisor.py` - Per-match strategic play analysis (per-turn suggestions)
    - `exceptions.py` - Custom exception types
 
 2. **`stats/`** - Django app (models, views, templates)
@@ -59,14 +60,12 @@ make ci          # Run check + test (use before commits)
    - `templates/` - Django templates
    - `static/` - CSS (`css/style.css`) and JS (`js/app.js`, `js/charts.js`)
 
-3. **`cards/`** - Django app for card image recognition
-   - `models.py` - `CardImage` model (upload, status, FK to `stats.Card`, phash match distance)
-   - `views.py` - Index, upload, detail, and photography guide views
-   - `forms.py` - `CardImageUploadForm` with 10 MB size validation
-   - `tasks.py` - Celery task `match_card_image`: computes phash, finds best match via Hamming distance (threshold: 12)
-   - `urls.py` - Mounted at `/cards/` (app_name = `cards`)
-   - `management/commands/build_phash_index.py` - CLI to batch-compute phashes for all `stats.Card` records
-   - `templates/cards/` - `index.html`, `upload.html`, `card_detail.html`
+3. **`cards/`** - Django app for physical (paper) card inventory
+   - `models.py` - `PaperCard` model: stores card metadata fetched from Scryfall named-card API
+   - `views.py` - `card_index`, `add_paper_card` (fuzzy name lookup → Scryfall), `paper_card_detail`
+   - `templatetags/cards_extras.py` - `mana_icons` and `cmc_value` template filters
+   - `urls.py` - Mounted at `/cards/` (app_name = `cards`); routes: `/`, `/add/`, `/paper/<pk>/`
+   - `templates/cards/` - `index.html` (sortable/searchable table), `add_paper_card.html`, `paper_card_detail.html`
 
 4. **`mtgas_project/`** - Django project configuration
    - `settings.py` - Django settings (INSTALLED_APPS, DATABASE, etc.)
@@ -211,14 +210,17 @@ LifeChange, ZoneTransfer
 
 ### `webapp-testing`
 - Dev server: `make run` → `http://127.0.0.1:8000`
-- Key routes: `/` (dashboard), `/import/`, `/card-data/`, `/cards/`, `/matches/`, `/decks/`
+- Key routes: `/` (dashboard), `/import/`, `/card-data/`, `/cards/` (paper card inventory), `/matches/`, `/decks/`
 
 ## Development Workflow
 
 1. **Branch**: Use feature branches (not main)
 2. **Format**: Run `make format` before committing
 3. **Test**: Run `make ci` to check format, lint, and tests
-4. **Docs**: After all changes, review and update any markdown docs (`README.md`, `CONTRIBUTING.md`, `QUICKSTART.md`, `docs/`) that are affected by or describe the changed behavior
+4. **Docs**: After all changes, review and update **every** markdown doc that is affected:
+   - `README.md`, `CONTRIBUTING.md`, `QUICKSTART.md` — top-level user-facing docs
+   - `docs/` — technical reference docs (`DATABASE_SCHEMA.md`, `DEVELOPMENT.md`, `LOG_PARSING.md`, `LOGGING.md`, `MATCH_REPLAY.md`)
+   - **Rule**: If your commit adds, removes, or changes a feature, model, route, command, or configuration value described in any of these files, update that file in the same commit. Do not leave docs stale.
 5. **Commit**: Use conventional commit prefixes:
    - `feat:` - New features
    - `fix:` - Bug fixes
@@ -228,17 +230,21 @@ LifeChange, ZoneTransfer
 
 ## Important Notes
 
-- **Card image recognition** (`cards/` app): Upload a card photo to `/cards/upload/`; a Celery task (`match_card_image`) computes a perceptual hash (phash) and finds the closest `stats.Card` by Hamming distance (threshold: 12)
-  - Requires Celery worker running alongside Django
-  - Before matching works, populate phashes: `python manage.py build_phash_index` (downloads images from Scryfall URLs stored in `stats.Card.image_uri`)
-  - `CardImage.status` lifecycle: `pending` → `processing` → `matched` | `unmatched` | `failed`
-  - Photography guide available at `/cards/photography-guide/`
+- **Paper Cards inventory** (`cards/` app): Catalogue physical MTG cards at `/cards/`
+  - Add a card by name at `/cards/add/` — uses Scryfall fuzzy named-card API to fetch metadata
+  - Card list (`/cards/`) is sortable by column and searchable; rows show mana icons via `mana_icons` template filter
+  - `PaperCard` is independent of the Arena `cards` table — tracks any physical card by name
+  - No Celery, no image upload, no phash — fully synchronous Scryfall lookups
 - **Import logging**: Comprehensive logging added to import process for debugging
   - Logger name: `stats.views`
-  - INFO level: Match-level progress, import summaries
+  - INFO level: Match-level progress, import summaries (including deck name/format updates)
   - DEBUG level: Detailed per-operation logging (deck creation, card lookups, bulk creates)
   - ERROR level: Full exception tracebacks with context data
   - Fixed bug: LifeChange model uses `change_amount` field (was incorrectly `change`)
+- **Deck versioning and analysis history**: Deck name/format are kept in sync on every import
+  - `_import_match` updates `Deck.name` and `Deck.format` whenever Arena reports a change (not just on creation)
+  - `_analyze_snapshot(snapshot)` in `stats/views/decks.py` computes analysis for any `DeckSnapshot`; used in both `deck_detail` and `deck_history` views
+  - The deck history page (`/deck/<id>/history/`) shows a collapsible analysis section for every version, so users can track how suggestions changed as the deck evolved
 - **Card image caching**: Deck gallery view downloads and caches Scryfall card images locally
   - Images stored in `data/cache/card_images/`
   - One-click batch download for all cards in a deck

--- a/stats/templates/deck_history.html
+++ b/stats/templates/deck_history.html
@@ -78,6 +78,33 @@
                 </div>
                 {% endif %}
             </div>
+            {% if entry.analysis.suggestions %}
+            <details class="mt-3">
+                <summary class="text-muted small">
+                    Analysis for this version
+                    <span class="badge bg-secondary ms-1">{{ entry.analysis.suggestions|length }} suggestion{{ entry.analysis.suggestions|length|pluralize }}</span>
+                    <span class="text-muted ms-2">avg CMC {{ entry.analysis.avg_cmc }} &middot; {{ entry.analysis.curve_shape }}</span>
+                </summary>
+                <div class="deck-suggestions mt-2">
+                    {% for s in entry.analysis.suggestions %}
+                    <div class="deck-suggestion deck-suggestion--{{ s.severity }}">
+                        <div class="deck-suggestion__header">
+                            <span class="deck-suggestion__badge">{{ s.category }}</span>
+                            <strong class="deck-suggestion__title">{{ s.title }}</strong>
+                        </div>
+                        <p class="deck-suggestion__body">{{ s.body }}</p>
+                    </div>
+                    {% endfor %}
+                </div>
+            </details>
+            {% else %}
+            <p class="text-muted small mt-2 mb-0">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" class="bi bi-check-circle-fill text-success me-1" viewBox="0 0 16 16">
+                    <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zm-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z"/>
+                </svg>
+                No issues found for this version &mdash; avg CMC {{ entry.analysis.avg_cmc }} &middot; {{ entry.analysis.curve_shape }}
+            </p>
+            {% endif %}
         </div>
         {% elif not entry.is_first %}
         <div class="card-body py-2 text-muted small">No changes from previous version.</div>
@@ -116,6 +143,33 @@
                     {% endif %}
                 </div>
             </details>
+            {% if entry.analysis.suggestions %}
+            <details class="mt-3">
+                <summary class="text-muted small">
+                    Analysis for this version
+                    <span class="badge bg-secondary ms-1">{{ entry.analysis.suggestions|length }} suggestion{{ entry.analysis.suggestions|length|pluralize }}</span>
+                    <span class="text-muted ms-2">avg CMC {{ entry.analysis.avg_cmc }} &middot; {{ entry.analysis.curve_shape }}</span>
+                </summary>
+                <div class="deck-suggestions mt-2">
+                    {% for s in entry.analysis.suggestions %}
+                    <div class="deck-suggestion deck-suggestion--{{ s.severity }}">
+                        <div class="deck-suggestion__header">
+                            <span class="deck-suggestion__badge">{{ s.category }}</span>
+                            <strong class="deck-suggestion__title">{{ s.title }}</strong>
+                        </div>
+                        <p class="deck-suggestion__body">{{ s.body }}</p>
+                    </div>
+                    {% endfor %}
+                </div>
+            </details>
+            {% else %}
+            <p class="text-muted small mt-2 mb-0">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" class="bi bi-check-circle-fill text-success me-1" viewBox="0 0 16 16">
+                    <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zm-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z"/>
+                </svg>
+                No issues found for this version &mdash; avg CMC {{ entry.analysis.avg_cmc }} &middot; {{ entry.analysis.curve_shape }}
+            </p>
+            {% endif %}
         </div>
         {% endif %}
     </div>

--- a/stats/views/decks.py
+++ b/stats/views/decks.py
@@ -406,6 +406,35 @@ def _categorize_cards(deck_cards):
     return cards_by_type, mana_curve, color_counts
 
 
+def _analyze_snapshot(snapshot: DeckSnapshot | None) -> dict[str, Any]:
+    """Compute deck analysis metrics for a given snapshot.
+
+    Returns the same dict as _compute_deck_suggestions, or an empty-suggestions
+    dict when snapshot is None (no card data yet).
+    """
+    if snapshot is None:
+        return {
+            "avg_cmc": 0.0,
+            "curve_shape": "Unknown",
+            "pip_counts": {},
+            "pip_pct": {},
+            "pip_summary": "",
+            "one_ofs": 0,
+            "two_ofs": 0,
+            "three_ofs": 0,
+            "four_ofs": 0,
+            "suggestions": [],
+        }
+    deck_cards = list(snapshot.cards.select_related("card").order_by("card__cmc", "card__name"))
+    cards_by_type, mana_curve, color_counts = _categorize_cards(deck_cards)
+    total_cards = sum(dc.quantity for dc in deck_cards)
+    total_lands = sum(dc.quantity for dc in deck_cards if "Land" in (dc.card.type_line or ""))
+    suggested_lands = round(total_cards * 17 / 40)
+    return _compute_deck_suggestions(
+        deck_cards, mana_curve, color_counts, total_cards, total_lands, suggested_lands
+    )
+
+
 def deck_detail(request: HttpRequest, deck_id: int) -> HttpResponse:
     """Detailed deck view — shows latest snapshot card list."""
     deck = get_object_or_404(Deck, pk=deck_id)
@@ -445,9 +474,7 @@ def deck_detail(request: HttpRequest, deck_id: int) -> HttpResponse:
     land_pct = round(total_lands / total_cards * 100, 1) if total_cards > 0 else 0
     suggested_lands = round(total_cards * 17 / 40)
 
-    deck_analysis = _compute_deck_suggestions(
-        deck_cards, mana_curve, color_counts, total_cards, total_lands, suggested_lands
-    )
+    deck_analysis = _analyze_snapshot(latest)
 
     return render(
         request,
@@ -491,6 +518,7 @@ def deck_history(request: HttpRequest, deck_id: int) -> HttpResponse:
                 "first_match": first_match,
                 "match_count": match_count,
                 "is_first": i == 0,
+                "analysis": _analyze_snapshot(snap),
             }
         )
 

--- a/stats/views/imports.py
+++ b/stats/views/imports.py
@@ -272,13 +272,28 @@ def _import_match(
     # Resolve deck identity — snapshot is created after Match
     deck = None
     if match_data.deck_id:
-        deck, _ = Deck.objects.get_or_create(
+        deck, created = Deck.objects.get_or_create(
             deck_id=match_data.deck_id,
             defaults={
                 "name": match_data.deck_name or "Unknown Deck",
                 "format": match_data.format,
             },
         )
+        if not created:
+            # Sync name and format if they've been updated in Arena
+            update_fields = []
+            new_name = match_data.deck_name or "Unknown Deck"
+            if deck.name != new_name:
+                deck.name = new_name
+                update_fields.append("name")
+            if match_data.format and deck.format != match_data.format:
+                deck.format = match_data.format
+                update_fields.append("format")
+            if update_fields:
+                deck.save(update_fields=update_fields + ["updated_at"])
+                logger.info(
+                    f"[{match_id}] Updated deck {deck.deck_id}: {', '.join(update_fields)} changed"
+                )
         logger.debug(f"[{match_id}] Deck ready: {deck.name}")
 
     # Collect all unique card IDs (includes instance data for better unknowns)


### PR DESCRIPTION
This pull request introduces several improvements and updates across documentation, backend logic, and frontend display, primarily focused on deck analysis, versioning, and the handling of paper card inventory. The most notable changes include a new deck analysis function for historical versions, enhanced deck versioning and analysis history, and a rework of the `cards` app to focus on paper card inventory instead of image recognition. Documentation has been updated to reflect these shifts and to enforce stricter requirements for keeping docs in sync with code changes.

**Deck analysis and versioning:**
- Added `_analyze_snapshot` function in `stats/views/decks.py` to compute deck analysis metrics for any deck snapshot, enabling consistent analysis for both the latest and historical versions. Deck detail and history views now use this function to display suggestions and metrics for each version. [[1]](diffhunk://#diff-ecc4545659e34434301fb01fe8d7d0dff28511a2bf303c94f18feedc98de5fccR409-R437) [[2]](diffhunk://#diff-ecc4545659e34434301fb01fe8d7d0dff28511a2bf303c94f18feedc98de5fccL448-R477) [[3]](diffhunk://#diff-ecc4545659e34434301fb01fe8d7d0dff28511a2bf303c94f18feedc98de5fccR521)
- Modified the import workflow in `stats/views/imports.py` so that deck name and format are always updated to match Arena data on every import, not just on deck creation. This ensures deck metadata stays in sync across imports.

**Frontend improvements:**
- Updated `deck_history.html` to show a detailed analysis section for each deck version, including suggestions, average CMC, and curve shape. If no suggestions are present, a "No issues found" message is shown. [[1]](diffhunk://#diff-21b41f974ac768cd8621efecc6d892cdb3b5d085d949923c062238353065da3aR81-R107) [[2]](diffhunk://#diff-21b41f974ac768cd8621efecc6d892cdb3b5d085d949923c062238353065da3aR146-R172)

**Documentation updates and enforcement:**
- Rewrote the `.github/copilot-instructions.md` to reflect the new focus of the `cards` app as a paper card inventory (not image recognition), and updated route descriptions accordingly. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L62-R68) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L214-R223) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L231-R247)
- Strengthened the documentation update policy: contributors must now review and update every affected markdown doc (including both top-level and technical docs) when making changes to features, models, routes, commands, or configuration values.

**Backend structure:**
- Added `services/play_advisor.py` to the documentation, clarifying its role in providing per-match strategic play analysis.

These changes collectively improve the accuracy, transparency, and usability of deck analysis and history, ensure documentation remains current, and clarify the project's structure and workflow.