### PR TITLE
feat: backup and restore UI

### DIFF
--- a/docs/BACKUPS.md
+++ b/docs/BACKUPS.md
@@ -1,0 +1,109 @@
+# Backup & Restore
+
+MTG Arena Stats includes a web UI for backing up and restoring the full database.
+Backups use Django's `dumpdata` format — a JSON file containing all app data —
+which is portable across both SQLite and PostgreSQL and is compatible with Django
+migrations (safe to restore after a schema upgrade when combined with a migration run).
+
+## Accessing the UI
+
+Navigate to **`/backup/`** (Backup link in the top nav).
+
+The page has two sections:
+
+- **Download Backup** — exports all data as a JSON file to your browser
+- **Restore from Backup** — uploads a previously downloaded backup and replaces all current data
+
+---
+
+## Downloading a Backup
+
+1. Go to `/backup/`
+2. Click **Download Backup**
+
+The file is saved to your browser's default download folder with the name:
+
+```
+mtgas_backup_YYYYMMDD_HHMMSS.json
+```
+
+The backup includes all records from the `stats` and `cards` apps:
+
+| App | Models included |
+|-----|----------------|
+| `stats` | Match, Deck, DeckSnapshot, DeckCard, Card, CardToken, CardTokenRef, GameAction, LifeChange, ZoneTransfer, ImportSession, UnknownCard |
+| `cards` | PaperCard |
+
+Django internal tables (`auth`, `sessions`, `admin`, `contenttypes`) are **not** included.
+
+---
+
+## Restoring a Backup
+
+> ⚠️ **Restore permanently deletes all existing data** before loading the backup.
+> Download a fresh backup first if you want to preserve your current data.
+
+1. Go to `/backup/`
+2. Under **Restore from Backup**, select a `.json` backup file
+3. Check the confirmation box
+4. Click **Restore Backup**
+
+The restore process:
+1. Validates the uploaded file is well-formed JSON
+2. Deletes all existing app data in foreign-key-safe order (within a transaction)
+3. Loads the backup with `loaddata`
+4. Redirects back to `/backup/` with a success or error message
+
+If the restore fails for any reason the transaction is rolled back and your existing
+data is left intact.
+
+---
+
+## Recommended Workflow: Migrating to a New Schema
+
+When the database schema changes (new migration), follow this order:
+
+```bash
+# 1. Download a backup via the UI at /backup/
+#    → saves mtgas_backup_YYYYMMDD_HHMMSS.json
+
+# 2. Apply the new migrations
+python manage.py migrate
+
+# 3. Restore the backup via the UI at /backup/
+#    The backup JSON uses natural keys so Django maps records to the
+#    updated schema automatically.
+```
+
+---
+
+## Backup Format
+
+Backups are produced by `django.core.management.call_command('dumpdata', ...)` with
+`natural_foreign=True` and `natural_primary=True`. Each record is a JSON object:
+
+```json
+[
+  {
+    "model": "stats.deck",
+    "fields": {
+      "deck_id": "abc123",
+      "name": "Red Deck Wins",
+      "format": "Standard",
+      ...
+    }
+  },
+  ...
+]
+```
+
+---
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "Invalid file type" error | Ensure the file has a `.json` extension |
+| "not valid JSON" error | The file may be corrupted; re-download a fresh backup |
+| Restore fails with integrity error | The backup may be from an incompatible schema version — run `python manage.py migrate` first, then retry |
+| Download is empty `[]` | The database has no data yet; this is expected on a fresh install |

--- a/stats/templates/backup.html
+++ b/stats/templates/backup.html
@@ -1,0 +1,98 @@
+{% extends "base.html" %}
+
+{% block title %}Backup & Restore - MTG Arena Stats{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="col-md-8 offset-md-2">
+        <h1 class="mb-4">Backup &amp; Restore</h1>
+
+        {% if messages %}
+            {% for message in messages %}
+            <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
+                {{ message }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+            </div>
+            {% endfor %}
+        {% endif %}
+
+        {# ── Backup ─────────────────────────────────────────────────────── #}
+        <div class="card mb-4">
+            <div class="card-header">
+                <strong>💾 Download Backup</strong>
+            </div>
+            <div class="card-body">
+                <p class="card-text">
+                    Download a full JSON backup of all your matches, decks, cards, and paper card inventory.
+                    The file can be used to restore your data later, even after a schema migration.
+                </p>
+                <a href="{% url 'stats:backup_download' %}" class="btn btn-primary">
+                    Download Backup
+                </a>
+            </div>
+        </div>
+
+        {# ── Restore ─────────────────────────────────────────────────────── #}
+        <div class="card">
+            <div class="card-header">
+                <strong>📂 Restore from Backup</strong>
+            </div>
+            <div class="card-body">
+                <div class="alert alert-danger mb-4" role="alert">
+                    <strong>⚠️ Warning — this is destructive.</strong>
+                    Restoring a backup will <strong>permanently delete all current data</strong>
+                    (matches, decks, cards, paper card inventory) and replace it with the contents
+                    of the uploaded file. This cannot be undone.
+                </div>
+
+                <form method="post" enctype="multipart/form-data">
+                    {% csrf_token %}
+
+                    <div class="mb-4">
+                        <label for="backup_file" class="form-label">
+                            <strong>Select Backup File</strong>
+                        </label>
+                        <input
+                            type="file"
+                            class="form-control"
+                            id="backup_file"
+                            name="backup_file"
+                            accept=".json"
+                            required
+                        >
+                        <div class="form-text">
+                            Upload a <code>.json</code> backup file previously downloaded from this page.
+                        </div>
+                    </div>
+
+                    <div class="mb-4">
+                        <div class="form-check">
+                            <input
+                                type="checkbox"
+                                class="form-check-input"
+                                id="confirmed"
+                                name="confirmed"
+                                required
+                            >
+                            <label class="form-check-label" for="confirmed">
+                                I understand that all existing data will be permanently deleted and replaced
+                                with the contents of this backup file.
+                            </label>
+                        </div>
+                    </div>
+
+                    <button type="submit" class="btn btn-danger">
+                        Restore Backup
+                    </button>
+                </form>
+            </div>
+        </div>
+
+        <div class="alert alert-info mt-4">
+            <strong>Tip:</strong> Download a backup before running database migrations or
+            upgrading to a new version of MTG Arena Stats.
+        </div>
+
+    </div>
+</div>
+{% endblock %}

--- a/stats/templates/base.html
+++ b/stats/templates/base.html
@@ -53,6 +53,9 @@
                     <li class="nav-item">
                         <a class="nav-link" href="{% url 'cards:index' %}">Paper Cards</a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{% url 'stats:backup' %}">Backup</a>
+                    </li>
                 </ul>
                 <button id="theme-toggle" class="theme-toggle ms-auto" aria-label="Toggle theme">☀</button>
             </div>

--- a/stats/urls.py
+++ b/stats/urls.py
@@ -23,5 +23,7 @@ urlpatterns = [
     path("card-data/", views.card_data, name="card_data"),
     path("unknown-cards/", views.unknown_cards_list, name="unknown_cards_list"),
     path("unknown-card/<int:grp_id>/fix/", views.unknown_card_fix, name="unknown_card_fix"),
+    path("backup/", views.backup_restore, name="backup"),
+    path("backup/download/", views.backup_download, name="backup_download"),
     path("api/stats/", views.api_stats, name="api_stats"),
 ]

--- a/stats/views/__init__.py
+++ b/stats/views/__init__.py
@@ -5,6 +5,7 @@ Re-exports all URL-facing views so that urls.py can continue to use
 ``from . import views`` and then ``views.dashboard`` etc. unchanged.
 """
 
+from .backup import backup_download, backup_restore
 from .cards import unknown_card_fix, unknown_cards_list
 from .dashboard import api_stats, dashboard
 from .decks import deck_detail, deck_gallery, deck_history, decks_list
@@ -27,4 +28,6 @@ __all__ = [
     "card_data",
     "unknown_cards_list",
     "unknown_card_fix",
+    "backup_download",
+    "backup_restore",
 ]

--- a/stats/views/backup.py
+++ b/stats/views/backup.py
@@ -1,0 +1,141 @@
+"""
+Backup and restore views for the stats app.
+
+Backup:  GET /backup/download/ — streams a dumpdata JSON file to the browser.
+Restore: GET /backup/           — shows the backup/restore page.
+         POST /backup/          — accepts an uploaded JSON backup and restores it.
+"""
+
+import io
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime
+
+from django.contrib import messages
+from django.core.management import call_command
+from django.db import transaction
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import redirect, render
+
+from ..models import (
+    Card,
+    CardToken,
+    CardTokenRef,
+    Deck,
+    DeckCard,
+    DeckSnapshot,
+    GameAction,
+    LifeChange,
+    Match,
+    UnknownCard,
+    ZoneTransfer,
+)
+
+logger = logging.getLogger("stats.views")
+
+# Models deleted during restore, ordered to respect FK constraints.
+_RESTORE_DELETE_ORDER = [
+    UnknownCard,
+    ZoneTransfer,
+    LifeChange,
+    GameAction,
+    DeckCard,
+    DeckSnapshot,
+    Match,
+    Deck,
+    CardTokenRef,
+    CardToken,
+    Card,
+]
+
+
+def backup_download(request: HttpRequest) -> HttpResponse:
+    """Stream a full JSON backup of all app data as a file download."""
+    buf = io.StringIO()
+    call_command(
+        "dumpdata",
+        "stats",
+        "cards",
+        indent=2,
+        stdout=buf,
+        natural_foreign=True,
+        natural_primary=True,
+    )
+    buf.seek(0)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"mtgas_backup_{timestamp}.json"
+
+    response = HttpResponse(buf.read(), content_type="application/json")
+    response["Content-Disposition"] = f'attachment; filename="{filename}"'
+    logger.info("Backup downloaded: %s", filename)
+    return response
+
+
+def backup_restore(request: HttpRequest) -> HttpResponse:
+    """Show backup/restore page (GET) or process an uploaded backup file (POST)."""
+    if request.method == "POST":
+        return _handle_restore(request)
+    return render(request, "backup.html")
+
+
+def _handle_restore(request: HttpRequest) -> HttpResponse:
+    """Validate the uploaded backup file and restore it into the database."""
+    backup_file = request.FILES.get("backup_file")
+    confirmed = request.POST.get("confirmed")
+
+    if not backup_file:
+        messages.error(request, "No backup file selected.")
+        return redirect("stats:backup")
+
+    if not confirmed:
+        messages.error(request, "You must confirm that you want to overwrite all existing data.")
+        return redirect("stats:backup")
+
+    if not backup_file.name.endswith(".json"):
+        messages.error(request, "Invalid file type. Please upload a .json backup file.")
+        return redirect("stats:backup")
+
+    # Write to a temp file so loaddata can read it from disk.
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="wb") as tmp:
+            for chunk in backup_file.chunks():
+                tmp.write(chunk)
+            tmp_path = tmp.name
+
+        # Validate that the file is parseable JSON before touching the DB.
+        with open(tmp_path, "r", encoding="utf-8") as f:
+            json.load(f)
+
+        with transaction.atomic():
+            _flush_app_data()
+            call_command("loaddata", tmp_path, verbosity=0)
+
+        logger.info("Database restored from backup: %s", backup_file.name)
+        messages.success(request, "Database restored successfully.")
+
+    except json.JSONDecodeError:
+        messages.error(request, "Invalid backup file: not valid JSON.")
+        logger.warning("Restore failed — invalid JSON: %s", backup_file.name)
+    except Exception as exc:
+        messages.error(request, f"Restore failed: {exc}")
+        logger.exception("Restore failed for file %s", backup_file.name)
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+    return redirect("stats:backup")
+
+
+def _flush_app_data() -> None:
+    """Delete all app data in FK-safe order before loading a backup."""
+    for model in _RESTORE_DELETE_ORDER:
+        model.objects.all().delete()
+
+    # PaperCard lives in the cards app — import here to avoid circular imports.
+    from cards.models import PaperCard
+
+    PaperCard.objects.all().delete()

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,177 @@
+"""
+Tests for backup and restore views.
+"""
+
+import json
+import sys
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch
+
+from django.test import Client
+from django.urls import reverse
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+@pytest.fixture
+def sample_db(db):
+    """Create minimal data so a backup has something to export."""
+    from stats.models import Card, Deck
+
+    Card.objects.create(grp_id=1, name="Lightning Bolt", type_line="Instant")
+    Deck.objects.create(deck_id="deck-001", name="Red Deck Wins", format="Standard")
+
+
+# ---------------------------------------------------------------------------
+# Backup download
+# ---------------------------------------------------------------------------
+
+
+class TestBackupDownload:
+    def test_returns_200(self, client, sample_db):
+        response = client.get(reverse("stats:backup_download"))
+        assert response.status_code == 200
+
+    def test_content_type_is_json(self, client, sample_db):
+        response = client.get(reverse("stats:backup_download"))
+        assert response["Content-Type"] == "application/json"
+
+    def test_content_disposition_is_attachment(self, client, sample_db):
+        response = client.get(reverse("stats:backup_download"))
+        disposition = response["Content-Disposition"]
+        assert disposition.startswith("attachment")
+        assert "mtgas_backup_" in disposition
+        assert ".json" in disposition
+
+    def test_response_body_is_valid_json(self, client, sample_db):
+        response = client.get(reverse("stats:backup_download"))
+        data = json.loads(
+            b"".join(response.streaming_content) if response.streaming else response.content
+        )
+        assert isinstance(data, list)
+
+    def test_response_contains_app_data(self, client, sample_db):
+        response = client.get(reverse("stats:backup_download"))
+        content = response.content.decode()
+        data = json.loads(content)
+        model_names = {item["model"] for item in data}
+        assert any(m.startswith("stats.") or m.startswith("cards.") for m in model_names)
+
+
+# ---------------------------------------------------------------------------
+# Backup/restore page (GET)
+# ---------------------------------------------------------------------------
+
+
+class TestBackupRestorePage:
+    def test_get_returns_200(self, client, db):
+        response = client.get(reverse("stats:backup"))
+        assert response.status_code == 200
+
+    def test_get_renders_backup_template(self, client, db):
+        response = client.get(reverse("stats:backup"))
+        assert "backup.html" in [t.name for t in response.templates]
+
+    def test_page_contains_download_link(self, client, db):
+        response = client.get(reverse("stats:backup"))
+        assert reverse("stats:backup_download").encode() in response.content
+
+    def test_page_contains_restore_form(self, client, db):
+        response = client.get(reverse("stats:backup"))
+        assert b'name="backup_file"' in response.content
+        assert b'name="confirmed"' in response.content
+
+
+# ---------------------------------------------------------------------------
+# Restore (POST)
+# ---------------------------------------------------------------------------
+
+
+class TestRestore:
+    def _make_backup_file(self, data: list) -> BytesIO:
+        """Return a BytesIO that looks like an uploaded .json backup."""
+        buf = BytesIO(json.dumps(data).encode())
+        buf.name = "mtgas_backup_test.json"
+        return buf
+
+    def test_restore_without_file_redirects_with_error(self, client, db):
+        response = client.post(
+            reverse("stats:backup"),
+            {"confirmed": "on"},
+        )
+        assert response.status_code == 302
+        follow = client.get(response["Location"])
+        messages = [str(m) for m in follow.context["messages"]]
+        assert any("No backup file" in m for m in messages)
+
+    def test_restore_without_confirmation_redirects_with_error(self, client, db):
+        buf = self._make_backup_file([])
+        response = client.post(
+            reverse("stats:backup"),
+            {"backup_file": buf},
+        )
+        assert response.status_code == 302
+        follow = client.get(response["Location"])
+        messages = [str(m) for m in follow.context["messages"]]
+        assert any("confirm" in m.lower() for m in messages)
+
+    def test_restore_with_invalid_json_shows_error(self, client, db):
+        bad_file = BytesIO(b"this is not json {{{")
+        bad_file.name = "bad.json"
+        response = client.post(
+            reverse("stats:backup"),
+            {"backup_file": bad_file, "confirmed": "on"},
+        )
+        assert response.status_code == 302
+        follow = client.get(response["Location"])
+        messages = [str(m) for m in follow.context["messages"]]
+        assert any("not valid JSON" in m or "Invalid" in m for m in messages)
+
+    def test_restore_with_wrong_extension_shows_error(self, client, db):
+        buf = BytesIO(b"data")
+        buf.name = "backup.txt"
+        response = client.post(
+            reverse("stats:backup"),
+            {"backup_file": buf, "confirmed": "on"},
+        )
+        assert response.status_code == 302
+        follow = client.get(response["Location"])
+        messages = [str(m) for m in follow.context["messages"]]
+        assert any("Invalid file type" in m for m in messages)
+
+    def test_restore_with_empty_backup_clears_data(self, client, sample_db):
+        from stats.models import Card, Deck
+
+        assert Card.objects.exists()
+        assert Deck.objects.exists()
+
+        buf = self._make_backup_file([])
+        with patch("stats.views.backup.call_command"):
+            response = client.post(
+                reverse("stats:backup"),
+                {"backup_file": buf, "confirmed": "on"},
+            )
+
+        assert response.status_code == 302
+        assert not Card.objects.exists()
+        assert not Deck.objects.exists()
+
+    def test_successful_restore_shows_success_message(self, client, db):
+        buf = self._make_backup_file([])
+        with patch("stats.views.backup.call_command"):
+            response = client.post(
+                reverse("stats:backup"),
+                {"backup_file": buf, "confirmed": "on"},
+            )
+        assert response.status_code == 302
+        follow = client.get(response["Location"])
+        messages = [str(m) for m in follow.context["messages"]]
+        assert any("success" in m.lower() or "restored" in m.lower() for m in messages)


### PR DESCRIPTION
## Summary

Adds a web-based backup and restore feature for the full database.

## Changes

### `stats/views/backup.py` _(new)_
- `GET /backup/download/` — streams a timestamped `dumpdata` JSON file to the browser (all `stats` + `cards` data)
- `GET /backup/` — renders the backup/restore page
- `POST /backup/` — validates the uploaded `.json`, flushes all app data in FK-safe order inside a transaction, then runs `loaddata`; requires confirmation checkbox

### `stats/templates/backup.html` _(new)_
- Download section with a single button
- Restore section with file upload, danger warning, and confirmation checkbox

### `stats/templates/base.html`
- Added **Backup** nav link

### `stats/views/__init__.py` + `stats/urls.py`
- Wired up `backup_restore` and `backup_download` views at `/backup/` and `/backup/download/`

### `tests/test_backup.py` _(new, 15 tests)_
- Download: status 200, correct content-type, `Content-Disposition` attachment, valid JSON body, app data present
- Page: renders template, contains download link and restore form
- Restore: no file, no confirmation, wrong extension, invalid JSON, successful restore (data cleared, success message)

### `docs/BACKUPS.md` _(new)_
- Full documentation: usage, included models, migration workflow, backup format, troubleshooting

Closes #22