### PR TITLE
feat: loading spinner on Import and Restore submit buttons (#34)

### DIFF
--- a/stats/static/css/style.css
+++ b/stats/static/css/style.css
@@ -1508,3 +1508,22 @@ details > summary {
 [data-bs-theme="dark"] .analysis-severity-badge.severity-tip {
     color: #60a5fa;
 }
+
+/* ── Submit-button loading spinner ───────────────────────────────────────── */
+
+@keyframes btn-spin {
+    to { transform: rotate(360deg); }
+}
+
+.btn-spinner {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    border: 2px solid currentcolor;
+    border-right-color: transparent;
+    border-radius: 50%;
+    animation: btn-spin 0.65s linear infinite;
+    vertical-align: -0.15em;
+    margin-right: 0.4em;
+    flex-shrink: 0;
+}

--- a/stats/static/js/app.js
+++ b/stats/static/js/app.js
@@ -124,6 +124,19 @@
         });
     }
 
+    // -------------------------------------------------------------------------
+    // Submit-button loading spinner
+    // -------------------------------------------------------------------------
+    function initSubmitSpinner(formId, btnId, label) {
+        const form = document.getElementById(formId);
+        const btn  = document.getElementById(btnId);
+        if (!form || !btn) return;
+        form.addEventListener("submit", function () {
+            btn.disabled = true;
+            btn.innerHTML = '<span class="btn-spinner" aria-hidden="true"></span>' + label;
+        });
+    }
+
     document.addEventListener("DOMContentLoaded", function () {
         const current = document.documentElement.getAttribute("data-theme") || DARK;
         applyTheme(current);
@@ -139,6 +152,8 @@
         initCardPreviews();
         initCardZoom();
         initCopyCardName();
+        initSubmitSpinner("import-form", "import-submit-btn", "Importing\u2026");
+        initSubmitSpinner("restore-form", "restore-submit-btn", "Restoring\u2026");
     });
 })();
 

--- a/stats/static/js/app.js
+++ b/stats/static/js/app.js
@@ -132,8 +132,12 @@
         const btn  = document.getElementById(btnId);
         if (!form || !btn) return;
         form.addEventListener("submit", function () {
+            const spinner = document.createElement("span");
+            spinner.className = "btn-spinner";
+            spinner.setAttribute("aria-hidden", "true");
+
             btn.disabled = true;
-            btn.innerHTML = '<span class="btn-spinner" aria-hidden="true"></span>' + label;
+            btn.replaceChildren(spinner, document.createTextNode(" " + label));
         });
     }
 

--- a/stats/templates/backup.html
+++ b/stats/templates/backup.html
@@ -45,7 +45,7 @@
                     of the uploaded file. This cannot be undone.
                 </div>
 
-                <form method="post" enctype="multipart/form-data">
+                <form id="restore-form" method="post" enctype="multipart/form-data">
                     {% csrf_token %}
 
                     <div class="mb-4">
@@ -81,7 +81,7 @@
                         </div>
                     </div>
 
-                    <button type="submit" class="btn btn-danger">
+                    <button type="submit" class="btn btn-danger" id="restore-submit-btn">
                         Restore Backup
                     </button>
                 </form>

--- a/stats/templates/import_log.html
+++ b/stats/templates/import_log.html
@@ -18,7 +18,7 @@
 
         <div class="card">
             <div class="card-body">
-                <form method="post" enctype="multipart/form-data">
+                <form id="import-form" method="post" enctype="multipart/form-data">
                     {% csrf_token %}
                     
                     <div class="mb-4">
@@ -54,7 +54,7 @@
                     </div>
 
                     <div class="d-grid gap-2">
-                        <button type="submit" class="btn btn-primary btn-lg">
+                        <button type="submit" class="btn btn-primary btn-lg" id="import-submit-btn">
                             Import Log File(s)
                         </button>
                         <a href="{% url 'stats:import_sessions' %}" class="btn btn-secondary">


### PR DESCRIPTION
## Summary

Closes #34

Pure front-end change — no AJAX, no new dependencies.

## Changes

| File | What changed |
|------|-------------|
| `stats/templates/import_log.html` | Added `id="import-form"` to form, `id="import-submit-btn"` to button |
| `stats/templates/backup.html` | Added `id="restore-form"` to restore form, `id="restore-submit-btn"` to button |
| `stats/static/js/app.js` | Added `initSubmitSpinner(formId, btnId, label)` helper; wired up both forms in `DOMContentLoaded` |
| `stats/static/css/style.css` | Added `@keyframes btn-spin` and `.btn-spinner` styles |

## Behaviour

- Clicking **Import Log File(s)** or **Restore Backup** immediately disables the button and shows a CSS spinner with contextual label ("Importing…" / "Restoring…")
- The `submit` event fires only after HTML5 validation passes, so the `required` guard on the file input still prevents submission when no file is selected
- The button reverts naturally when the page redirects after the server responds
- The spinner is a pure CSS `border-radius: 50%` element animated with `@keyframes` — no external libraries

## Test Results

All 179 tests pass (`make ci` clean).