### PR TITLE
docs: update CONTRIBUTING.md with branch/PR conventions, doc rules, and Copilot workflow (#28)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,6 +8,8 @@ Django web application for tracking and analyzing Magic: The Gathering Arena gam
 
 ## Build & Test Commands
 
+> **Convention**: always prefer `make` targets over invoking tools directly. Every common workflow has a target; use `.venv/bin/<tool>` only when you need flags or arguments that no `make` target exposes, and document why in the commit message.
+
 ### Setup
 ```bash
 make setup              # Install dev dependencies + run migrations (installs into .venv)
@@ -25,11 +27,15 @@ make import-log LOG=/path/to/Player.log  # Import MTGA log file (CLI)
 
 ### Testing
 ```bash
-.venv/bin/pytest                          # Run all tests
-.venv/bin/pytest tests/test_parser.py     # Run specific test file
-.venv/bin/pytest tests/test_models.py::TestMatchModel  # Run specific test class
-.venv/bin/pytest -k "test_parse_match"    # Run tests matching pattern
-.venv/bin/pytest --cov=stats --cov=src --cov=cards  # Run with coverage
+make test                   # Run all tests
+make test-verbose           # Run with verbose output and long tracebacks
+make test-cov               # Run with HTML + terminal coverage report
+make test-parser            # Run parser tests only
+make test-models            # Run model tests only
+make test-views             # Run view tests only
+# Need flags make doesn't expose? Call pytest directly (prefer make targets otherwise):
+.venv/bin/pytest tests/test_parser.py::TestMatchParsing  # specific class
+.venv/bin/pytest -k "test_parse_match"                   # pattern match
 ```
 
 ### Code Quality
@@ -164,9 +170,9 @@ LifeChange, ZoneTransfer
 
 ### Adding a New Model
 1. Add model to `stats/models.py`
-2. Run `python manage.py makemigrations`
+2. Run `make makemigrations`
 3. Review migration file
-4. Run `python manage.py migrate`
+4. Run `make migrate`
 5. Register in `stats/admin.py` if needed
 6. Add tests in `tests/test_models.py`
 
@@ -203,7 +209,8 @@ LifeChange, ZoneTransfer
 - Templates: `stats/templates/`, `cards/templates/`; JS: `stats/static/js/`
 
 ### `polyglot-test-agent`
-- Run tests with `.venv/bin/pytest` (not bare `pytest`)
+- Run tests with `make test` (preferred) or `make test-cov` for coverage
+- Use `.venv/bin/pytest <args>` only when you need flags not exposed by a make target (e.g., `-k` pattern or a specific class); never use bare `pytest`
 - Coverage targets: `--cov=stats --cov=src --cov=cards`
 - Test naming: `test_<function>_<scenario>`
 - Fixtures in `conftest.py`; test database is in-memory SQLite

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,13 +87,18 @@ All new features should include tests:
 
 ```bash
 # Run all tests
-.venv/bin/pytest
+make test
 
-# Run with coverage
-.venv/bin/pytest --cov=stats --cov=src --cov=cards
+# Run with coverage report
+make test-cov
 
-# Run specific tests
-.venv/bin/pytest tests/test_parser.py -v
+# Run with verbose output
+make test-verbose
+
+# Run specific test files
+make test-parser   # parser tests only
+make test-models   # model tests only
+make test-views    # view tests only
 ```
 
 ## Pull Request Process

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for your interest in contributing! This document provides guidelines a
 1. Fork the repository
 2. Clone your fork locally
 3. Set up the development environment (see below)
-4. Create a feature branch from `main`
+4. Create a feature branch from `develop` (see [Branch & PR Conventions](#branch--pr-conventions))
 
 ## Development Setup
 
@@ -87,35 +87,35 @@ All new features should include tests:
 
 ```bash
 # Run all tests
-make test
+.venv/bin/pytest
 
 # Run with coverage
-make test-cov
+.venv/bin/pytest --cov=stats --cov=src --cov=cards
 
 # Run specific tests
-pytest tests/test_parser.py -v
+.venv/bin/pytest tests/test_parser.py -v
 ```
 
 ## Pull Request Process
 
-1. **Create a branch**: `git checkout -b feature/your-feature-name`
+1. **Create a branch** from `develop` using the `issue-{number}-{short-description}` naming convention (see [Branch & PR Conventions](#branch--pr-conventions))
 
 2. **Make changes**: Follow code standards
 
 3. **Test**: Ensure `make ci` passes
 
-4. **Commit**: Use descriptive commit messages
+4. **Commit**: Use conventional commit prefixes:
    - `feat:` for new features
    - `fix:` for bug fixes
    - `docs:` for documentation
    - `test:` for tests
    - `refactor:` for refactoring
 
-5. **Push**: `git push origin feature/your-feature-name`
+5. **Push**: `git push origin issue-{number}-{short-description}`
 
-6. **Open PR**: Submit a pull request with:
+6. **Open PR** targeting `develop` with:
    - Clear description of changes
-   - Link to related issues
+   - Link to the related issue (`Closes #N`)
    - Screenshots for UI changes
 
 ## Project Structure
@@ -131,6 +131,82 @@ pytest tests/test_parser.py -v
 - Update `README.md` for user-facing changes
 - Update `docs/` for technical documentation
 - Add docstrings to new functions/classes
+
+## Branch & PR Conventions
+
+Every piece of work must follow this branching model:
+
+| Rule | Detail |
+|------|--------|
+| **Branch base** | Always cut from `develop` — never from `main` |
+| **Branch name** | `issue-{number}-{short-description}` — e.g., `issue-34-import-spinner` |
+| **PR target** | Always target `develop` — never `main` |
+| **Merging to `main`** | Only via a release PR from `develop` |
+| **CI gate** | `make ci` must pass before merging |
+| **Issue link** | Every branch must be linked to a GitHub issue; create one first if none exists |
+
+```bash
+# Start work on issue #42
+git checkout develop
+git pull
+git checkout -b issue-42-my-feature
+# … make changes …
+make ci
+git push -u origin issue-42-my-feature
+# Open PR targeting develop on GitHub
+```
+
+## Documenting Feature Changes
+
+After every code change, update **every** doc file that describes the affected feature:
+
+| File | When to update |
+|------|---------------|
+| `README.md` | User-facing features, routes, setup steps |
+| `QUICKSTART.md` | Quick-start commands or first-run steps |
+| `docs/DATABASE_SCHEMA.md` | Model or schema changes |
+| `docs/DEVELOPMENT.md` | Dev workflow, commands, or architecture changes |
+| `docs/LOG_PARSING.md` | Parser changes or new event types |
+| `docs/LOGGING.md` | Logging config or logger-name changes |
+| `docs/MATCH_REPLAY.md` | Match replay or game-action changes |
+
+**Rule**: if your commit adds, removes, or changes a feature, model, route, management command, or configuration value that is described in any of the files above, update that file in the **same commit**. Do not leave docs stale.
+
+## Using Copilot to Work on Issues
+
+### Writing a good issue
+
+Clear issues produce better results from both humans and Copilot. Follow the templates below.
+
+**Bug report**
+- Title: short and specific — *"Import fails when log has duplicate match IDs"*
+- Body: steps to reproduce, expected vs. actual behaviour, environment, full traceback in a fenced code block
+- Labels: `bug`
+
+**Feature request**
+- Title: action-oriented — *"Add deck win-rate chart to dashboard"*
+- Body: problem statement, proposed solution, alternatives considered, acceptance criteria
+- Labels: `enhancement`
+
+**General rules**: one issue = one concern; link related issues/PRs with `#N`; add screenshots or logs.
+
+```markdown
+### Acceptance Criteria
+- [ ] <observable outcome 1>
+- [ ] <observable outcome 2>
+- [ ] Tests cover the new behaviour
+```
+
+### Picking up an issue with Copilot
+
+Copilot reads `.github/copilot-instructions.md` for project-specific conventions. To start work on an existing issue:
+
+1. Reference the issue number when prompting — e.g., *"Let's work on issue #42"*
+2. Copilot will create the branch `issue-42-{description}` from `develop` automatically
+3. All commits and the PR description will reference the issue
+4. Copilot will run `make ci` before pushing and will open the PR targeting `develop`
+
+To write a new issue before handing it to Copilot, follow the templates above and include clear acceptance criteria — Copilot uses them to know when the task is complete.
 
 ## Questions?
 


### PR DESCRIPTION
## Summary

Closes #28

Updates `CONTRIBUTING.md` to match the conventions in `.github/copilot-instructions.md` and adds three new sections requested in the issue.

## Changes

### Fixed (stale content)
- Branch base: `main` → `develop`
- Branch naming: `feature/...` → `issue-{number}-{short-description}`
- PR target: clarified as `develop` (never `main`)
- Test commands: `make test` / bare `pytest` → `.venv/bin/pytest`

### Added
| Section | Content |
|---------|---------|
| **Branch & PR Conventions** | Table of rules, code example, CI gate requirement |
| **Documenting Feature Changes** | Per-file table of when to update each doc; "never leave docs stale" rule |
| **Using Copilot to Work on Issues** | Issue writing templates (bug/feature), acceptance-criteria pattern, step-by-step guide for picking up an issue with Copilot |

## Acceptance Criteria
- [x] `CONTRIBUTING.md` includes a section on documenting feature changes
- [x] `CONTRIBUTING.md` includes a section on using Copilot to create and pick up issues
- [x] `CONTRIBUTING.md` includes branch naming and PR convention rules
- [x] All rules are consistent with `.github/copilot-instructions.md`