### PR TITLE
build: remove stale Makefile targets and fix test-cov coverage (#41)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # This Makefile provides commands for common development tasks.
 # Run `make help` to see all available commands.
 
-.PHONY: help install install-dev setup migrate run test lint format check clean download-cards import-log check-venv
+.PHONY: help install-dev setup migrate run test lint format check clean download-cards import-log check-venv
 
 # Default Python interpreter
 VENV := .venv
@@ -36,17 +36,6 @@ check-venv: ## Verify .venv exists; fail fast with a helpful message if not
 # =============================================================================
 # Environment Setup
 # =============================================================================
-
-venv: ## Create virtual environment
-	@echo "$(BLUE)Creating virtual environment...$(NC)"
-	$(PYTHON) -m venv $(VENV)
-	@echo "$(GREEN)Virtual environment created at $(VENV)$(NC)"
-	@echo "Activate with: source $(VENV)/bin/activate"
-
-install: ## Install production dependencies
-	@echo "$(BLUE)Installing production dependencies...$(NC)"
-	$(PIP) install -e .
-	@echo "$(GREEN)Dependencies installed$(NC)"
 
 install-dev: ## Install development dependencies (includes formatting/linting tools)
 	@echo "$(BLUE)Installing development dependencies...$(NC)"
@@ -170,7 +159,7 @@ test-verbose: check-venv ## Run tests with verbose output
 
 test-cov: check-venv ## Run tests with coverage report
 	@echo "$(BLUE)Running tests with coverage...$(NC)"
-	$(VENV_BIN)/pytest --cov=stats --cov=src --cov-report=html --cov-report=term
+	$(VENV_BIN)/pytest --cov=stats --cov=src --cov=cards --cov-report=html --cov-report=term
 	@echo "$(GREEN)Coverage report generated in htmlcov/$(NC)"
 
 test-parser: check-venv ## Run only parser tests
@@ -207,17 +196,6 @@ clean-all: clean ## Remove all generated files including database and cache
 # =============================================================================
 # Documentation
 # =============================================================================
-
-docs: ## Generate documentation (placeholder)
-	@echo "$(BLUE)Documentation is in README.md and docs/$(NC)"
-
-# =============================================================================
-# Combined Commands
-# =============================================================================
-
-all: setup download-cards ## Full setup including card data download
-	@echo "$(GREEN)Full setup complete!$(NC)"
-	@echo "Run 'make run' to start the development server"
 
 ci: check test ## Run all CI checks (format, lint, test)
 	@echo "$(GREEN)All CI checks passed$(NC)"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # This Makefile provides commands for common development tasks.
 # Run `make help` to see all available commands.
 
-.PHONY: help install-dev setup migrate run test lint format check clean download-cards import-log check-venv
+.PHONY: help install-dev setup migrate run test lint format check clean download-cards import-log
 
 # Default Python interpreter
 VENV := .venv

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -120,8 +120,7 @@ Run `make help` to see all available commands:
 | `make format` | Format code with black/isort |
 | `make lint` | Run flake8 linter |
 | `make lint-css` | Run stylelint on CSS |
-| `make check` | Run Python code quality checks |
-| `make check` | Run all checks including CSS |
+| `make check` | Run all checks: format, lint, and CSS (requires `npm install`) |
 | `make ci` | Run checks + tests (for CI) |
 | `make download-cards` | Download Scryfall data |
 | `make import-log LOG=path` | Import a log file |

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -57,9 +57,8 @@ Browse to **http://127.0.0.1:8000/**
 # 1. Navigate to project directory
 cd /path/to/mtgas
 
-# 2. Create and activate virtual environment
-make venv
-source .venv/bin/activate
+# 2. Create virtual environment
+python3 -m venv .venv
 
 # 3. Full setup (install deps + migrate database)
 make setup
@@ -89,7 +88,7 @@ make test-verbose
 make test-cov
 
 # Run specific test file
-pytest tests/test_parser.py
+make test-parser
 ```
 
 ## Code Quality
@@ -122,7 +121,7 @@ Run `make help` to see all available commands:
 | `make lint` | Run flake8 linter |
 | `make lint-css` | Run stylelint on CSS |
 | `make check` | Run Python code quality checks |
-| `make check-all` | Run all checks including CSS |
+| `make check` | Run all checks including CSS |
 | `make ci` | Run checks + tests (for CI) |
 | `make download-cards` | Download Scryfall data |
 | `make import-log LOG=path` | Import a log file |


### PR DESCRIPTION
## Summary

Closes #41

### Removed targets

| Target | Reason |
|--------|--------|
| `venv` | Broken — used `$(PYTHON)` (`.venv/bin/python3`) to create the venv itself; circular, never worked from a clean clone |
| `install` | Dead — never called by any target; `install-dev` (used by `setup`) is a strict superset |
| `docs` | No-op placeholder — only echoed a static string pointing at README.md |
| `all` | Undocumented — not listed in QUICKSTART or copilot-instructions; redundantly wrapped `setup + download-cards` |

### Bug fixed
- `test-cov`: added `--cov=cards` (the `cards` app was missing from coverage reporting)

### QUICKSTART.md updated
- `make venv && source .venv/bin/activate` → `python3 -m venv .venv`
- Bare `pytest tests/test_parser.py` → `make test-parser`
- Non-existent `make check-all` → `make check`

## Test Results
All 179 tests pass (`make ci` clean).