### PR TITLE
feat: tag local dev container images with branch name and short commit ID (#31)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,9 @@ CELERY_BROKER_URL=redis://redis:6379/0
 
 # ─── Timezone (optional) ──────────────────────────────────────────────────────
 # TIME_ZONE=America/New_York
+
+# ─── Docker image tagging (set automatically by make docker-build / docker-up) ─
+# These are exported by the Makefile from `git rev-parse`. Override only if you
+# are building outside of make (e.g. bare `docker compose build`).
+# GIT_BRANCH=local
+# GIT_SHA=dev

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,11 @@
 # This Makefile provides commands for common development tasks.
 # Run `make help` to see all available commands.
 
-.PHONY: help install-dev setup migrate run test lint format check clean download-cards import-log
+.PHONY: help install-dev setup migrate run test lint format check clean download-cards import-log docker-build docker-up docker-down
+
+# Git metadata for Docker image tagging
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-')
+GIT_SHA    := $(shell git rev-parse --short HEAD 2>/dev/null)
 
 # Default Python interpreter
 VENV := .venv
@@ -170,6 +174,24 @@ test-models: check-venv ## Run only model tests
 
 test-views: check-venv ## Run only view tests
 	$(VENV_BIN)/pytest tests/test_views.py -v
+
+# =============================================================================
+# Docker
+# =============================================================================
+
+docker-build: ## Build the dev container image tagged with branch and commit SHA
+	@echo "$(BLUE)Building Docker image: mtgas:$(GIT_BRANCH)-$(GIT_SHA)$(NC)"
+	GIT_BRANCH=$(GIT_BRANCH) GIT_SHA=$(GIT_SHA) docker compose build
+	@echo "$(GREEN)Image built: mtgas:$(GIT_BRANCH)-$(GIT_SHA)$(NC)"
+
+docker-up: ## Start all services (builds image if needed)
+	@echo "$(BLUE)Starting services (mtgas:$(GIT_BRANCH)-$(GIT_SHA))...$(NC)"
+	GIT_BRANCH=$(GIT_BRANCH) GIT_SHA=$(GIT_SHA) docker compose up
+
+docker-down: ## Stop and remove containers
+	@echo "$(BLUE)Stopping services...$(NC)"
+	docker compose down
+	@echo "$(GREEN)Services stopped$(NC)"
 
 # =============================================================================
 # Cleanup

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,16 @@
 # This Makefile provides commands for common development tasks.
 # Run `make help` to see all available commands.
 
-.PHONY: help install-dev setup migrate run test lint format check clean download-cards import-log docker-build docker-up docker-down
+.PHONY: help check-venv install-dev setup migrate makemigrations resetdb run shell createsuperuser \
+        test test-verbose test-cov test-parser test-models test-views \
+        format format-check lint lint-css lint-css-fix check ci \
+        download-cards import-log import-default \
+        docker-build docker-up docker-down \
+        clean clean-all
 
 # Git metadata for Docker image tagging
-GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-')
-GIT_SHA    := $(shell git rev-parse --short HEAD 2>/dev/null)
+GIT_BRANCH := $(or $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-'),local)
+GIT_SHA    := $(or $(shell git rev-parse --short HEAD 2>/dev/null),dev)
 
 # Default Python interpreter
 VENV := .venv
@@ -184,9 +189,9 @@ docker-build: ## Build the dev container image tagged with branch and commit SHA
 	GIT_BRANCH=$(GIT_BRANCH) GIT_SHA=$(GIT_SHA) docker compose build
 	@echo "$(GREEN)Image built: mtgas:$(GIT_BRANCH)-$(GIT_SHA)$(NC)"
 
-docker-up: ## Start all services (builds image if needed)
+docker-up: ## Start all services, rebuilding the image if the build context changed
 	@echo "$(BLUE)Starting services (mtgas:$(GIT_BRANCH)-$(GIT_SHA))...$(NC)"
-	GIT_BRANCH=$(GIT_BRANCH) GIT_SHA=$(GIT_SHA) docker compose up
+	GIT_BRANCH=$(GIT_BRANCH) GIT_SHA=$(GIT_SHA) docker compose up --build
 
 docker-down: ## Stop and remove containers
 	@echo "$(BLUE)Stopping services...$(NC)"

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -21,10 +21,18 @@ The defaults work out of the box for local development.
 ### 2. Start all services
 
 ```bash
-docker compose up --build
+make docker-up
 ```
 
-This builds the image (first run only, subsequent runs are fast), then starts `web` and `postgres`.
+This exports the current git branch and short commit SHA, then starts `web` and `postgres`. The built image is tagged `mtgas:<branch>-<sha>` (e.g. `mtgas:main-a1b2c3d`).
+
+To build the image without starting services:
+
+```bash
+make docker-build
+```
+
+> **Bare `docker compose` commands** still work but will tag the image as `mtgas:local-dev` unless you export `GIT_BRANCH` and `GIT_SHA` yourself.
 
 ### 3. Run migrations and download card data
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -24,7 +24,7 @@ The defaults work out of the box for local development.
 make docker-up
 ```
 
-This exports the current git branch and short commit SHA, then starts `web` and `postgres`. The built image is tagged `mtgas:<branch>-<sha>` (e.g. `mtgas:main-a1b2c3d`).
+This exports the current git branch and short commit SHA, builds the image (rebuilding automatically if the Dockerfile or build context changed), then starts `web` and `postgres`. The built image is tagged `mtgas:<branch>-<sha>` (e.g. `mtgas:main-a1b2c3d`).
 
 To build the image without starting services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   # ─── Django web application ────────────────────────────────────────────────
   web:
     build: .
+    image: mtgas:${GIT_BRANCH:-local}-${GIT_SHA:-dev}
     volumes:
       - .:/app                  # bind mount: live code changes reflected immediately
       - /app/.venv              # shadow local .venv so container Python is used


### PR DESCRIPTION
## Summary

Closes #31

Tags the local dev Docker image as `mtgas:<branch>-<sha>` (e.g. `mtgas:issue-31-docker-image-tagging-afef7d5`) so you can always tell which branch and commit a running container was built from.

### Changes

| File | Change |
|------|--------|
| `Makefile` | Add `GIT_BRANCH` / `GIT_SHA` vars; add `docker-build`, `docker-up`, `docker-down` targets |
| `docker-compose.yml` | Add `image: mtgas:${GIT_BRANCH:-local}-${GIT_SHA:-dev}` to `web` service |
| `.env.example` | Document `GIT_BRANCH` / `GIT_SHA` with defaults |
| `QUICKSTART.md` | Replace bare `docker compose up --build` with `make docker-up` / `make docker-build` |

### Behaviour
- `make docker-build` / `make docker-up` automatically export the git vars
- Bare `docker compose` commands fall back to `mtgas:local-dev` if vars are not set
- Branch name slashes are replaced with hyphens via `tr '/' '-'`

## Test Results
All 179 tests pass (`make ci` clean).